### PR TITLE
Temp changes in terraform and Dockerfile for "chyba"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY --from=gradle --chown=nonroot:nonroot /home/gradle/backend/backend/build/di
 WORKDIR "/app"
 USER nonroot
 
-ENTRYPOINT ["java","-Xmx256m","-jar","./loono-be.jar"]
+ENTRYPOINT ["java","-Xmx450m","-jar","./loono-be.jar"]

--- a/infrastructure/aws/backend.tf
+++ b/infrastructure/aws/backend.tf
@@ -136,7 +136,7 @@ resource "aws_ecs_service" "backend" {
   cluster                            = aws_ecs_cluster.backend.id
   task_definition                    = aws_ecs_task_definition.backend.arn
   launch_type                        = "FARGATE"
-  desired_count                      = 1
+  desired_count                      = 2
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 20
@@ -217,7 +217,8 @@ resource "aws_lb_target_group" "backend-tg" {
   target_type = "ip"
   health_check {
     path                = "/actuator/health"
-    unhealthy_threshold = 10
+    interval = 10
+    unhealthy_threshold = 3
     enabled             = true
     port                = 8080
     matcher             = "200"


### PR DESCRIPTION
Extending heap to 450m (Dockerfile)
desired_count = 2 for aws_ecs_service to give some high availability
unhealthy_threshold = 3 and interval = 10 to get 30s total healtcheck fail action

after merging new docker image must be built and pushed to aws_ecr_repository