### PR TITLE
Introduce prometheus metrics with simple counter example

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-security")
 
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
     implementation("com.google.firebase:firebase-admin:8.1.0")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
 

--- a/backend/src/main/kotlin/cz/loono/backend/api/service/HealthcareProvidersService.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/api/service/HealthcareProvidersService.kt
@@ -18,6 +18,7 @@ import cz.loono.backend.db.model.ServerProperties
 import cz.loono.backend.db.repository.HealthcareCategoryRepository
 import cz.loono.backend.db.repository.HealthcareProviderRepository
 import cz.loono.backend.db.repository.ServerPropertiesRepository
+import io.micrometer.core.annotation.Counted
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
@@ -213,6 +214,9 @@ class HealthcareProvidersService(
         zipFilePath = filePath
     }
 
+    @Counted(
+        "healthcare_providers_get_all_data",
+        description = "Total number of getting all healthcare providers simple data")
     fun getAllSimpleData(): Path {
         if (updating) {
             throw throw LoonoBackendException(

--- a/backend/src/main/kotlin/cz/loono/backend/configuration/MetricsConfiguration.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/configuration/MetricsConfiguration.kt
@@ -1,0 +1,23 @@
+package cz.loono.backend.configuration
+
+import io.micrometer.core.aop.CountedAspect
+import io.micrometer.core.aop.TimedAspect
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class MetricsConfiguration {
+
+    @Bean
+    fun timedAspect(registry: MeterRegistry): TimedAspect {
+        return TimedAspect(registry)
+    }
+
+    @Bean
+    fun countedAspect(registry: MeterRegistry): CountedAspect {
+        return CountedAspect(registry)
+    }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,6 +39,13 @@ management.endpoint.health.show-details: always
 management.health:
   db.enabled: true
   diskspace.enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+
 scheduler.cron:
   daily-task: "0 0 3 * * ?"
   data-update: "0 0 2 2 * ?"


### PR DESCRIPTION
- Prometheus metrics are available on unsecured endpoint `actuator/prometheus`. The endpoint provide JVM, DB connection, controller metrics, and more.
- For custom metric @Counted and @Timed annotation might be used.
- Simple metric `healthcare_providers_get_all_data` is used for demo purpose. It's available under `healthcare_providers_get_all_data_total` metric name

**Example of controller metrics:**
```
http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 4.0
http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.075313416
http_server_requests_seconds_count{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/v1/providers/all",} 3.0
http_server_requests_seconds_sum{exception="None",method="GET",outcome="SUCCESS",status="200",uri="/v1/providers/all",} 0.050859417
```

**Example of custom metrics:**
```
# HELP healthcare_providers_get_all_data_total Total number of getting all healthcare providers simple data
# TYPE healthcare_providers_get_all_data_total counter
healthcare_providers_get_all_data_total{class="cz.loono.backend.api.service.HealthcareProvidersService",exception="none",method="getAllSimpleData",result="success",} 1.0
```

**Example of JVM metrics:**
```
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytes{area="heap",id="G1 Survivor Space",} 824800.0
jvm_memory_used_bytes{area="heap",id="G1 Old Gen",} 1.41605376E8
jvm_memory_used_bytes{area="nonheap",id="Metaspace",} 9.8012864E7
jvm_memory_used_bytes{area="nonheap",id="CodeCache",} 2.138176E7
jvm_memory_used_bytes{area="heap",id="G1 Eden Space",} 2.9360128E7
jvm_memory_used_bytes{area="nonheap",id="Compressed Class Space",} 1.3260072E7
```