### PR TITLE
Added Prometheus metrics setup and two sample counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ The server uses Spring Actuator for the Health Check. The Health Check is hidden
 </p>
 <h3>Basic health check endpoints</h3>
 <p>
-Activated only default and database checks. We can enable more if needed.
+Activated only default, database checks and metrics for Prometheus. We can enable more if needed.
 </p>
 <ul>
 <li>Overall status: /actuator/health</li>
 <li>Database status: /actuator/health/db</li>
+<li>Prometheus metrics: /actuator/prometheus</li>
 </ul>
 <h2>API documentation</h2>
 <ul>

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("org.slf4j:slf4j-api:1.7.36")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("ch.qos.logback:logback-core:$logbackVersion")
+    implementation("io.micrometer:micrometer-registry-prometheus")
 
     runtimeOnly("org.postgresql:postgresql:42.4.1")
     implementation("org.hibernate:hibernate-envers:$hibernateVersion")

--- a/backend/src/main/kotlin/cz/loono/backend/api/v1/SwaggerController.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/api/v1/SwaggerController.kt
@@ -1,5 +1,6 @@
 package cz.loono.backend.api.v1
 
+import io.micrometer.core.annotation.Counted
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ResponseBody
@@ -9,6 +10,7 @@ class SwaggerController {
 
     @GetMapping(value = ["v1/api-docs"], produces = ["application/json"], headers = ["app-version"])
     @ResponseBody
+    @Counted(value = "swagger.docs.counter")
     fun getOpenAPI(): String = javaClass
         .getResourceAsStream("/doc/openapi.json")
         .bufferedReader().use {

--- a/backend/src/main/kotlin/cz/loono/backend/metrics/MetricsConfig.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/metrics/MetricsConfig.kt
@@ -1,0 +1,15 @@
+package cz.loono.backend.metrics
+
+import io.micrometer.core.aop.CountedAspect
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MetricsConfig {
+
+    @Bean
+    fun countedAspect(registry: MeterRegistry): CountedAspect {
+        return CountedAspect(registry)
+    }
+}

--- a/backend/src/main/kotlin/cz/loono/backend/security/SupportedAppVersionInterceptor.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/security/SupportedAppVersionInterceptor.kt
@@ -1,6 +1,8 @@
 package cz.loono.backend.security
 
 import cz.loono.backend.db.repository.ServerPropertiesRepository
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
 import org.apache.http.HttpStatus
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -10,7 +12,8 @@ import javax.servlet.http.HttpServletResponse
 
 @Component
 class SupportedAppVersionInterceptor(
-    private val serverPropertiesRepository: ServerPropertiesRepository
+    private val serverPropertiesRepository: ServerPropertiesRepository,
+    meterRegistry: MeterRegistry
 ) : HandlerInterceptor {
 
     private val supportedVersion: Int by lazy {
@@ -18,9 +21,14 @@ class SupportedAppVersionInterceptor(
     }
 
     private val logger = LoggerFactory.getLogger(javaClass)
+    private val counter: Counter
+
+    init {
+        counter = meterRegistry.counter("supported.version.counter")
+    }
 
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
-
+        counter.increment()
         val appVersion = request.getHeader("app-version")
         val supported = isSupported(appVersion)
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,6 +37,11 @@ server:
   error.path: "/error"
 # Health indicators
 management.endpoint.health.show-details: always
+management:
+  endpoints:
+    web:
+      exposure:
+        include: [ "health", "prometheus" ]
 management.health:
   db.enabled: true
   diskspace.enabled: false

--- a/backend/src/test/kotlin/cz/loono/backend/security/SupportedAppAppVersionInterceptorTest.kt
+++ b/backend/src/test/kotlin/cz/loono/backend/security/SupportedAppAppVersionInterceptorTest.kt
@@ -2,6 +2,7 @@ package cz.loono.backend.security
 
 import cz.loono.backend.db.model.ServerProperties
 import cz.loono.backend.db.repository.ServerPropertiesRepository
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -12,7 +13,7 @@ class SupportedAppAppVersionInterceptorTest {
 
     private val response: HttpServletResponse = mock()
     private val serverPropertiesRepository: ServerPropertiesRepository = mock()
-    private val interceptor = SupportedAppVersionInterceptor(serverPropertiesRepository)
+    private val interceptor = SupportedAppVersionInterceptor(serverPropertiesRepository, SimpleMeterRegistry())
 
     @Test
     fun `latest App version`() {


### PR DESCRIPTION
Metrics can be accessed using `/actuator/prometheus` endpoint. The endpoint is not secured (it's the same for others existing /actuator/** endpoints). I noticed that `SupportedAppVersionInterceptor` bean throws errors for those endpoints so it is the same for the new one. 

There are many built-in metrics available there - such as JVM memory metrics etc.

I also added two sample counters. 
The first one increments each time `SupportedAppVersionInterceptor` takes place, which is almost for every request. This one is implemented using imperative approach.
The second one was added in a more declarative manner for `v1/api-docs` endpoint. For this purpose it was necessary to declare `CountedAspect` bean in a new configuration class `MetricsConfig`.